### PR TITLE
fix: adds initial .dockerignore files

### DIFF
--- a/go/standard/.dockerignore
+++ b/go/standard/.dockerignore
@@ -1,0 +1,33 @@
+# Suga specific
+.suga/
+terraform/
+
+# Git
+.git/
+.gitignore
+
+# Environment variables
+.env
+.env.local
+
+# Logs
+*.log
+
+# Documentation
+README.md
+
+# Go binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Go build cache
+.cache/
+
+# Test binaries
+*.test
+
+# Go workspace file
+go.work

--- a/go/standard/.dockerignore
+++ b/go/standard/.dockerignore
@@ -26,6 +26,11 @@ README.md
 # Go build cache
 .cache/
 
+# IDE
+.DS_Store
+.vscode/
+.idea/
+
 # Test binaries
 *.test
 

--- a/python/django/.dockerignore
+++ b/python/django/.dockerignore
@@ -1,0 +1,54 @@
+# Suga specific
+.suga/
+terraform/
+
+# Git
+.git/
+.gitignore
+
+# Environment variables
+.env
+.env.local
+
+# Logs
+*.log
+
+# Documentation
+README.md
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Virtual environment
+.venv/
+venv/
+env/
+ENV/
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Django specific
+db.sqlite3
+db.sqlite3-journal
+staticfiles/
+media/
+*.pot
+
+# Testing
+.pytest_cache/
+.coverage
+.tox/
+htmlcov/
+.hypothesis/
+
+# IDE
+.DS_Store
+.python-version

--- a/python/uv/.dockerignore
+++ b/python/uv/.dockerignore
@@ -1,0 +1,49 @@
+# Suga specific
+.suga/
+terraform/
+
+# Git
+.git/
+.gitignore
+
+# Environment variables
+.env
+.env.local
+
+# Logs
+*.log
+
+# Documentation
+README.md
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Virtual environment
+.venv/
+venv/
+env/
+ENV/
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Testing
+.pytest_cache/
+.coverage
+.tox/
+htmlcov/
+.hypothesis/
+
+# IDE
+.DS_Store
+
+# UV specific
+.python-version

--- a/typescript/express/.dockerignore
+++ b/typescript/express/.dockerignore
@@ -1,0 +1,46 @@
+# Suga specific
+.suga/
+terraform/
+
+# Git
+.git/
+.gitignore
+
+# Environment variables
+.env
+.env.local
+
+# Logs
+*.log
+logs/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Documentation
+README.md
+
+# Node
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Build outputs
+dist/
+build/
+
+# TypeScript
+*.tsbuildinfo
+*.tgz
+
+# Testing
+coverage/
+.nyc_output/
+
+# IDE
+.DS_Store
+.vscode/
+.idea/
+
+# OS
+Thumbs.db


### PR DESCRIPTION
Adds `.dockerignore` files for various language environments (Go, Python, and Typescript) to exclude unnecessary files and
directories from the Docker image, improving build times and image size.

closes NIT-363